### PR TITLE
Improvements to hljs setup

### DIFF
--- a/src/helpers.js
+++ b/src/helpers.js
@@ -13,9 +13,17 @@ try {
 
 const AUTO_LANGUAGE = 'auto'
 
+// Iterate over the string and replace code characters as needed
+const escapeString = string => [].map.call(string, s => {
+    if (s.match(/</)) return '&lt;';
+    else if (s.match(/>/)) return '&gt;';
+    else if (s.match(/\n/)) return '<br/>';
+    else return s;
+}).join('')
+
 export const getDisplayString = (string, { lang }) => {
     if (lang === undefined) {
-        return `<code>${string}</code>`;
+        return `<code>${escapeString(string)}</code>`;
     }
 
     if (!hljs) {
@@ -32,7 +40,7 @@ export const getDisplayString = (string, { lang }) => {
         return `<code class="hljs ${lang}">${highlighted.value}</code>`;
     }
 
-    return `<code>${string}</code>`;
+    return `<code>${escapeString(string)}</code>`;
 };
 
 export const getClipboardString = string => string

--- a/src/helpers.js
+++ b/src/helpers.js
@@ -11,41 +11,28 @@ try {
     // do nothing
 }
 
-// Iterate over the string and replace code characters as needed
-const escapeString = string => [].map.call(string, s => {
-    if (s.match(/</)) return '&lt;';
-    else if (s.match(/>/)) return '&gt;';
-    else if (s.match(/\n/)) return '<br/>'
-    else return s;
-}).join('')
-
 const AUTO_LANGUAGE = 'auto'
 
 export const getDisplayString = (string, { lang }) => {
-    const escaped = escapeString(string)
-    const codeBlock = document.createElement('code');
-    codeBlock.innerHTML = escaped;
-
     if (lang === undefined) {
-        return codeBlock.outerHTML;
+        return `<code>${string}</code>`;
     }
 
     if (!hljs) {
         // falls back to not using hljs
-        console.warn('hightlight.js is not available')
+        console.warn('hightlight.js is not available');
     } else if (lang !== AUTO_LANGUAGE && !hljs.getLanguage(lang)) {
         // falls back to not using hljs
-        console.warn(`hightlight.js does not recognize the language '${lang}'.`)
+        console.warn(`hightlight.js does not recognize the language '${lang}'.`);
     } else {
-        hljs.configure({ useBR: true })
-        if (lang !== AUTO_LANGUAGE) {
-            codeBlock.className = `${lang}`;
-        }
+        const highlighted = lang !== AUTO_LANGUAGE
+            ? hljs.highlight(lang, string, true)
+            : hljs.highlightAuto(string);
 
-        hljs.highlightBlock(codeBlock);
+        return `<code class="hljs ${lang}">${highlighted.value}</code>`;
     }
 
-    return codeBlock.outerHTML;
+    return `<code>${string}</code>`;
 };
 
 export const getClipboardString = string => string


### PR DESCRIPTION
I realized that since we're in a `<pre>` block, we shouldn't have to do any modifying of the code at all.  In fact, it was causing problems when we were escaping things before we sent them to `hljs`; that's why you were seeing things not show up right when you didn't have spaces at the start of each line.  

This should fix that as well as a couple of other issues I was seeing when I was running storybook on your branch.