### PR TITLE
#11 - Fixes misspelled aria-labelledby attribute on container element

### DIFF
--- a/src/copyCodeBlock.js
+++ b/src/copyCodeBlock.js
@@ -25,7 +25,7 @@ export default (string, opts = {}) => {
     })();`;
 
     const code = `
-        <div class='${container}' aria-labeledby='${labelId}' tabindex='0'>
+        <div class='${container}' aria-labelledby='${labelId}' tabindex='0'>
             <span id='${labelId}' class='${containerLabel}'>${label}</span>
             <pre class='${displayCode}'>${getDisplayString(string, opts)}</pre>
             <button


### PR DESCRIPTION
Quick fix for a mispelled aria-labelled by attribute on the main container tag